### PR TITLE
fix(client): remove unused default React import to satisfy TS6133

### DIFF
--- a/client/src/layouts/AppLayout.tsx
+++ b/client/src/layouts/AppLayout.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense } from 'react'
+import { Suspense } from 'react'
 import { Outlet } from 'react-router-dom'
 
 // import Sidebar from '../components/Sidebar'

--- a/client/src/layouts/PublicLayout.tsx
+++ b/client/src/layouts/PublicLayout.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense } from 'react'
+import { Suspense } from 'react'
 import { Outlet } from 'react-router-dom'
 
 const LoadingFallback = () => <div>Đang tải...</div>;


### PR DESCRIPTION
This pull request makes a minor update to the import statements in the layout files. The change removes the unused default `React` import from both `AppLayout.tsx` and `PublicLayout.tsx`, keeping only the necessary named imports.